### PR TITLE
refactor type definition for render method.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export type ForgoComponent<TProps extends ForgoElementProps> = {
   render: (
     props: TProps,
     args: ForgoRenderArgs
-  ) => ForgoElement<ForgoComponentCtor<TProps>, TProps>;
+  ) => ForgoNode;
   error?: (
     props: TProps,
     args: ForgoErrorArgs

--- a/test/src/primitiveComponent/index.tsx
+++ b/test/src/primitiveComponent/index.tsx
@@ -128,5 +128,22 @@ export default function isForgoElement() {
       mountedDom.innerHTML.should.containEql(BigInt(Number.MAX_SAFE_INTEGER + 1))
     });
 
+    it("renders normal JSX component", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runNormalComponent(dom);
+  
+      const mountedDom = await new Promise<any>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.getElementById("root"));
+        });
+      });
+      mountedDom.innerHTML.should.containEql("bar")
+    });
+
   });
 }

--- a/test/src/primitiveComponent/index.tsx
+++ b/test/src/primitiveComponent/index.tsx
@@ -1,0 +1,132 @@
+import { JSDOM } from "jsdom";
+import htmlFile from "../htmlFile";
+import "should";
+import * as run from "./script";
+
+export default function isForgoElement() {
+  describe("renders primitive components", () => {
+    it("renders string value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runStringComponent(dom);
+  
+      const innerHtml = await new Promise<string>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.body.innerHTML);
+        });
+      });
+  
+      innerHtml.should.containEql("hello bar");
+    });
+
+    it("renders number value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runNumericComponent(dom);
+  
+      const innerHtml = await new Promise<string>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.body.innerHTML);
+        });
+      });
+  
+      innerHtml.should.containEql("100");
+    });
+
+    it("renders boolean value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runBooleanComponent(dom);
+  
+      const innerHtml = await new Promise<string>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.body.innerHTML);
+        });
+      });
+  
+      innerHtml.should.containEql("true");
+    });
+
+    it("renders object value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runObjectComponent(dom);
+  
+      const innerHtml = await new Promise<string>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.body.innerHTML);
+        });
+      });
+  
+      innerHtml.should.containEql({label:"bar"});
+    });
+
+    it("renders null value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runNullComponent(dom);
+  
+      const mountedDom = await new Promise<any>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.getElementById("root"));
+        });
+      });
+      mountedDom.childElementCount.should.equal(0)
+    });
+
+    it("renders undefined value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runUndefinedComponent(dom);
+  
+      const mountedDom = await new Promise<any>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.getElementById("root"));
+        });
+      });
+      mountedDom.childElementCount.should.equal(0)
+    });
+
+    it("renders BigInt value", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+  
+      run.runBigIntComponent(dom);
+  
+      const mountedDom = await new Promise<any>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve(window.document.getElementById("root"));
+        });
+      });
+      mountedDom.innerHTML.should.containEql(BigInt(Number.MAX_SAFE_INTEGER + 1))
+    });
+
+  });
+}

--- a/test/src/primitiveComponent/script.tsx
+++ b/test/src/primitiveComponent/script.tsx
@@ -1,0 +1,142 @@
+import { DOMWindow, JSDOM } from "jsdom";
+import {
+  ForgoComponent,
+  ForgoElementProps,
+  mount,
+  setCustomEnv,
+  ForgoErrorArgs,
+  ForgoElement
+} from "../../../";
+
+let window: DOMWindow;
+let document: HTMLDocument;
+
+type ComponentProps =  ForgoElementProps & {
+  foo: string | number | boolean | object | null | BigInt | undefined;
+}
+
+function StringComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return `hello ${foo}.` 
+    },
+  };
+}
+
+function NumericComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return Number(foo)
+    },
+  };
+}
+
+function BooleanComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return true
+    },
+  };
+}
+
+function ObjectComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return {foo}
+    },
+  };
+}
+
+function NullComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return null
+    },
+  };
+}
+
+function UndefinedComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return undefined
+    },
+  };
+}
+
+function BigIntComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}:ComponentProps) {
+      return BigInt(Number.MAX_SAFE_INTEGER + 1)
+    },
+  };
+}
+
+export function runStringComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<StringComponent foo="bar" />, "#root")
+  });
+}
+
+export function runNumericComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<NumericComponent foo={100} />, "#root")
+  });
+}
+
+export function runBooleanComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<BooleanComponent foo={100} />, "#root")
+  });
+}
+
+export function runObjectComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<ObjectComponent foo="bar" />, "#root")
+  });
+}
+
+export function runNullComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<NullComponent foo="bar" />, "#root")
+  });
+}
+
+export function runUndefinedComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<UndefinedComponent foo="bar" />, "#root")
+  });
+}
+
+export function runBigIntComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<BigIntComponent foo={100} />, "#root")
+  });
+}

--- a/test/src/primitiveComponent/script.tsx
+++ b/test/src/primitiveComponent/script.tsx
@@ -71,6 +71,14 @@ function BigIntComponent(): ForgoComponent<ComponentProps> {
   };
 }
 
+function NormalComponent(): ForgoComponent<ComponentProps> {
+  return {
+    render({foo}) {
+      return <div>{foo}</div>
+    },
+  };
+}
+
 export function runStringComponent(dom: JSDOM) {
   window = dom.window;
   document = window.document;
@@ -138,5 +146,15 @@ export function runBigIntComponent(dom: JSDOM) {
 
   window.addEventListener("load", () => {
     mount(<BigIntComponent foo={100} />, "#root")
+  });
+}
+
+export function runNormalComponent(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<NormalComponent foo="bar" />, "#root")
   });
 }

--- a/test/src/test.ts
+++ b/test/src/test.ts
@@ -13,6 +13,7 @@ import clearsProps from "./clearsProps";
 import shouldUpdate from "./shouldUpdate";
 import renderPrimitives from "./renderPrimitives";
 import assertIsComponent from "./assertIsComponent";
+import primitiveComponent from "./primitiveComponent";
 
 boundary();
 mount();
@@ -29,3 +30,4 @@ clearsProps();
 shouldUpdate();
 renderPrimitives();
 assertIsComponent();
+primitiveComponent();


### PR DESCRIPTION
The following component definition results in compile error.
```typescript
function FooComponent(): ForgoComponent<ForgoElementProps> {
  return {
    render() {
      return `hello foo.` 
    },
  };
}
```
It could be resolved by this refactoring.