### PR TITLE
package.json exports the minified build instead of the raw tsc output

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "https://github.com/forgojs/forgo"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-    "./jsx-runtime": "./jsx-runtime.js",
-    "./": "./"
+    ".": {
+      "import": "./dist/forgo.min.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.13",
@@ -28,8 +28,8 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "build": "npm run clean && mkdir -p dist && npx tsc && npx esbuild src/index.ts --minify --sourcemap --target=es2015 --outfile=dist/forgo.min.js",
-    "test": "npx mocha dist/test/test.js"
+    "build": "npm run clean && mkdir -p dist && npx tsc --emitDeclarationOnly && npx esbuild src/index.ts --minify --sourcemap --target=es2015 --outfile=dist/forgo.min.js",
+    "test": "npx tsc && npx mocha dist/test/test.js"
   },
   "license": "MIT"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -703,7 +703,9 @@ export function createForgoInstance(customEnv: any) {
           props: forgoElement.props,
         };
 
-        const statesToAttach = pendingAttachStates.concat(updatedComponentState);
+        const statesToAttach = pendingAttachStates.concat(
+          updatedComponentState
+        );
 
         const previousNode = componentState.args.element.node;
 
@@ -1756,7 +1758,7 @@ function findNodeIndex(
 }
 
 /* JSX Types */
-import { JSXTypes } from "./jsxTypes";
+import type { JSXTypes } from "./jsxTypes";
 
 declare global {
   interface ChildNode {
@@ -1765,8 +1767,4 @@ declare global {
   }
 }
 
-export import JSX = JSXTypes;
-
-export namespace createElement {
-  export import JSX = JSXTypes;
-}
+export { JSXTypes as JSX };


### PR DESCRIPTION
Currently package.json exports the 42KB `tsc` output rather than the minified esbuild output (noticed by using rollup-plugin-visualizer and seeing forgo was much larger than expected).

This PR:
- Points the `package.json` export at the minified build
- Removes what appear to be unused pre-2.0 exports
- Fixes the `./jsxTypes` import to not create a broken minified build 
  - (esbuild leaves the `import ...` in, but doesn't generate `jsxTypes.js` with `--outfile`. If changed to `--outdir`, it generates _empty_ `jsxTypes.js` because it doesn't export anything at runtime, and that turns into a build-time error in the project consuming forgo.)
- Updates the `tsc` step to not generate compiled output in `build`, but only for `test`
  - (the exported code doesn't use it, and this will prevent regressions)
- Removes the `createElement` namespace, because it emits error `ts1194` after changing to `import type ...`. Everything in my project works without that namespace declared, but lemme know if it's necessary and I'll put it back with a comment and figure out the types re-export.