### PR TITLE
Make Fragment symbol comparable across module instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ export type RenderResult = {
   Fragment constructor.
   We simply use it as a marker in jsx-runtime.
 */
-export const Fragment: unique symbol = Symbol("FORGO_FRAGMENT");
+export const Fragment: unique symbol = Symbol.for("FORGO_FRAGMENT");
 
 /*
   HTML Namespaces


### PR DESCRIPTION
When debugging Forgo using `npm link`, Vite's pre-bundling optimization executes the `forgo` module twice ([Vite bug](https://github.com/vitejs/vite/issues/3910), [Svelte bug with workarounds](https://github.com/sveltejs/vite-plugin-svelte/issues/135#issuecomment-894592028)). It doesn't happen when using the package from npm.

This results in different code paths holding references to two different `Fragment` symbols, causing renders to fail because the two symbols aren't comparable using `===`. Using `Symbol.for()` makes all symbols named `FORGO_FRAGMENT` comparable, no matter where they come from.

Alternatively, there's a workaround to have Vite disable pre-bundling optimizations for `forgo`, but this patch makes that unnecessary.