### PR TITLE
Don't set ref & dangerouslySetInnerHTML attributes on DOM nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export type ForgoElementProps = {
   children?: ForgoNode | ForgoNode[];
 };
 
+// Since we'll set any attribute the user passes us, we need to be sure not to
+// set Forgo-only attributes that don't make sense to appear in the DOM
+const suppressedAttributes = ["ref", "dangerouslySetInnerHTML"];
 export type ForgoDOMElementProps = {
   xmlns?: string;
   ref?: ForgoRef<Element>;
@@ -1268,6 +1271,8 @@ export function createForgoInstance(customEnv: any) {
       //  - do a (key in element) check.
       const entries = Object.entries(forgoNode.props);
       for (const [key, value] of entries) {
+        if (suppressedAttributes.includes(key)) continue;
+
         // The browser will sometimes perform side effects if an attribute is
         // set, even if its value hasn't changed, so only update attrs if
         // necessary. See issue #32.

--- a/src/test/afterRender/index.ts
+++ b/src/test/afterRender/index.ts
@@ -7,6 +7,8 @@ import {
   renderAgain,
   run,
   runWithTextNode,
+  runWithRef,
+  runWithDangerouslySetInnerHtml,
 } from "./script.js";
 import should from "should";
 
@@ -65,6 +67,47 @@ export default function () {
       renderAgain();
       should.equal((previousNode as Element).nodeType, 3);
       should.equal(counterX10, 30);
+    });
+  });
+
+  describe("setting an element's attributes", () => {
+    it("skips the 'ref' attribute", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+
+      runWithRef(dom);
+
+      await new Promise<void>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve();
+        });
+      });
+
+      should.equal((currentNode as Element).getAttribute("ref"), undefined);
+    });
+
+    it("skips the 'dangerouslySetInnerHtml' attribute", async () => {
+      const dom = new JSDOM(htmlFile(), {
+        runScripts: "outside-only",
+        resources: "usable",
+      });
+      const window = dom.window;
+
+      runWithDangerouslySetInnerHtml(dom);
+
+      await new Promise<void>((resolve) => {
+        window.addEventListener("load", () => {
+          resolve();
+        });
+      });
+
+      should.equal(
+        (currentNode as Element).getAttribute("dangerouslySetInnerHTML"),
+        undefined
+      );
     });
   });
 }

--- a/src/test/afterRender/script.tsx
+++ b/src/test/afterRender/script.tsx
@@ -60,6 +60,28 @@ function ComponentOnTextNode() {
   };
 }
 
+function ComponentWithRef() {
+  const ref: forgo.ForgoRef<HTMLDivElement> = {};
+  return {
+    render() {
+      return <div ref={ref} />;
+    },
+    afterRender(_props: any, args: ForgoAfterRenderArgs) {
+      currentNode = args.element.node as Element;
+    },
+  };
+}
+function ComponentWithDangerouslySetInnerHTML() {
+  return {
+    render() {
+      return <div dangerouslySetInnerHTML={{ __html: "<div></div>" }} />;
+    },
+    afterRender(_props: any, args: ForgoAfterRenderArgs) {
+      currentNode = args.element.node as Element;
+    },
+  };
+}
+
 export function run(dom: JSDOM) {
   window = dom.window;
   document = window.document;
@@ -77,5 +99,27 @@ export function runWithTextNode(dom: JSDOM) {
 
   window.addEventListener("load", () => {
     mount(<ComponentOnTextNode />, window.document.getElementById("root"));
+  });
+}
+
+export function runWithRef(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(<ComponentWithRef />, window.document.getElementById("root"));
+  });
+}
+export function runWithDangerouslySetInnerHtml(dom: JSDOM) {
+  window = dom.window;
+  document = window.document;
+  setCustomEnv({ window, document });
+
+  window.addEventListener("load", () => {
+    mount(
+      <ComponentWithDangerouslySetInnerHTML />,
+      window.document.getElementById("root")
+    );
   });
 }


### PR DESCRIPTION
Since updating Forgo to pass along non-standard attributes to DOM elements, it's also been passing along `ref` and `dangerouslySetInnerHtml` because it just blindly converts all props to attributes.

This change establishes a list of props to suppress from becoming attributes, to keep the DOM tidy and free of things that'll never make sense.