### PR TITLE
Fix for dropping components if we used falsey keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1186,16 +1186,17 @@ export function createForgoInstance(customEnv: any) {
       const node = nodes[i] as ChildNode;
       if (nodeIsElement(node)) {
         const stateOnNode = getForgoState(node);
-        if (forgoElement.key) {
-          if (stateOnNode?.key === forgoElement.key) {
-            return { found: true, index: i };
-          }
+        if (
+          forgoElement.key !== undefined &&
+          stateOnNode?.key === forgoElement.key
+        ) {
+          return { found: true, index: i };
         } else {
           // If the candidate has a key defined,
           //  we don't match it with an unkeyed forgo element
           if (
             node.tagName.toLowerCase() === forgoElement.type &&
-            (!stateOnNode || !stateOnNode.key)
+            !stateOnNode?.key
           ) {
             return { found: true, index: i };
           }
@@ -1203,7 +1204,7 @@ export function createForgoInstance(customEnv: any) {
       }
     }
     // Let's check deleted nodes as well.
-    if (forgoElement.key) {
+    if (forgoElement.key !== undefined) {
       const deletedNodes = getDeletedNodes(parentElement);
       for (let i = 0; i < deletedNodes.length; i++) {
         const { node } = deletedNodes[i];
@@ -1243,7 +1244,7 @@ export function createForgoInstance(customEnv: any) {
       const node = nodes[i] as ChildNode;
       const stateOnNode = getForgoState(node);
       if (stateOnNode && stateOnNode.components.length > componentIndex) {
-        if (forgoElement.key) {
+        if (forgoElement.key !== undefined) {
           if (
             stateOnNode.components[componentIndex].ctor === forgoElement.type &&
             stateOnNode.components[componentIndex].key === forgoElement.key
@@ -1268,7 +1269,10 @@ export function createForgoInstance(customEnv: any) {
     ) {
       const stateOnNode = getForgoState(node);
       if (stateOnNode && stateOnNode.components.length > componentIndex) {
-        if (stateOnNode.components[componentIndex].ctor === forgoElement.type && stateOnNode.components[componentIndex].key === forgoElement.key) {
+        if (
+          stateOnNode.components[componentIndex].ctor === forgoElement.type &&
+          stateOnNode.components[componentIndex].key === forgoElement.key
+        ) {
           return true;
         }
       }
@@ -1276,16 +1280,12 @@ export function createForgoInstance(customEnv: any) {
     }
 
     // Let's check deleted nodes as well.
-    if (forgoElement.key) {
+    if (forgoElement.key !== undefined) {
       const deletedNodes = getDeletedNodes(parentElement);
       for (let i = 0; i < deletedNodes.length; i++) {
         const { node: deletedNode } = deletedNodes[i];
         if (
-          nodeBelongsToKeyedComponent(
-            deletedNode,
-            forgoElement,
-            componentIndex
-          )
+          nodeBelongsToKeyedComponent(deletedNode, forgoElement, componentIndex)
         ) {
           const nodesToResurrect: ChildNode[] = [deletedNode];
           // Found a match!

--- a/src/test/componentKeepsStateWhenReordered/index.ts
+++ b/src/test/componentKeepsStateWhenReordered/index.ts
@@ -14,7 +14,7 @@ export default function () {
 
     run(dom);
 
-    const savedState = await new Promise<Record<string, string>>((resolve) => {
+    const savedState = await new Promise<Map<unknown, string>>((resolve) => {
       window.addEventListener("load", () => {
         resolve(getComponentState());
       });
@@ -23,25 +23,15 @@ export default function () {
     reorderComponents();
     const newState = getComponentState();
 
-    newState["1"].should.equal(
-      savedState["1"],
-      "component 1 state is mismatched"
-    );
-    newState["2"].should.equal(
-      savedState["2"],
-      "component 2 state is mismatched"
-    );
-    newState["3"].should.equal(
-      savedState["3"],
-      "component 3 state is mismatched"
-    );
-    newState["4"].should.equal(
-      savedState["4"],
-      "component 4 state is mismatched"
-    );
-    newState["5"].should.equal(
-      savedState["5"],
-      "component 5 state is mismatched"
-    );
+    // We explicitly test with a falsey value (zero) to catch if we use the
+    // shorthand `if (key)` rather than the required `if (key !== undefined)`
+    [0, "1", "2", "3", "4", "5"].forEach((key) => {
+      newState
+        .get(key)!
+        .should.equal(
+          savedState.get(key),
+          `component with key=${key} state is mismatched`
+        );
+    });
   });
 }

--- a/src/test/componentKeepsStateWhenReordered/script.tsx
+++ b/src/test/componentKeepsStateWhenReordered/script.tsx
@@ -9,7 +9,7 @@ function getRandomString() {
   );
 }
 
-let savedState: { [key: string]: string } = {};
+const savedState = new Map<unknown, string>();
 
 export function getComponentState() {
   return savedState;
@@ -19,12 +19,15 @@ function StatefulComponent() {
   let state = getRandomString();
   return {
     render({ key }: { key: string }) {
-      savedState[key] = state;
+      savedState.set(key, state);
       return (
         <p state={state} key={key}>
-          Component #${key}
+          Component #{key}
         </p>
       );
+    },
+    unmount({ key }: { key: string }) {
+      savedState.delete(key);
     },
   };
 }
@@ -39,13 +42,14 @@ export function reorderComponents() {
 
 function ContainerComponent() {
   return {
-    render(props: {}, args: forgo.ForgoRenderArgs) {
-      savedState = {};
+    render(_props: {}, args: forgo.ForgoRenderArgs) {
+      savedState.clear();
       containerArgs = args;
       return (
         <div>
           {sortOrder === 1 ? (
             <>
+              <StatefulComponent key={0} />
               <StatefulComponent key="1" />
               <StatefulComponent key="2" />
               <StatefulComponent key="3" />
@@ -57,6 +61,7 @@ function ContainerComponent() {
               <StatefulComponent key="1" />
               <StatefulComponent key="4" />
               <StatefulComponent key="3" />
+              <StatefulComponent key={0} />
               <StatefulComponent key="2" />
               <StatefulComponent key="5" />
             </>


### PR DESCRIPTION
If a component has a falsey key (`0`, `false`, `null`) Forgo thinks it has no key, and winds up dropping components or declining to reorder components/elements.

This patch updates all key checks to check specifically for `key !== undefined` so that all defined values get recognized as keys.