### PR TITLE
Simplify componentRunner

### DIFF
--- a/src/test/componentRunner.tsx
+++ b/src/test/componentRunner.tsx
@@ -2,14 +2,9 @@ import * as forgo from "../index.js";
 import htmlFile from "./htmlFile.js";
 import { DOMWindow, JSDOM } from "jsdom";
 
-export interface ComponentEnvironment<ExportedValues extends {}> {
+export interface ComponentEnvironment {
   window: DOMWindow;
   document: Document;
-  /**
-   * We use this to allow the component under test to return values to the testing
-   * environment, for making assertions about its internal state
-   */
-  exports: ExportedValues;
 }
 
 function defaultDom() {
@@ -32,15 +27,10 @@ function defaultDom() {
  * because we want tests to be able to set their own per-test props on a
  * component, which only works if the test declares the props as JSX
  */
-export async function run<TProps, TExports>(
-  componentBuilder: (
-    props: TProps,
-    window: DOMWindow,
-    document: Document
-  ) => {
+export async function run<TProps>(
+  componentBuilder: (env: ComponentEnvironment) => {
     node: forgo.ForgoNode;
   },
-  props: TProps,
   dom: JSDOM = defaultDom()
 ): Promise<{
   dom: JSDOM;
@@ -51,7 +41,7 @@ export async function run<TProps, TExports>(
   const document = window.document;
   forgo.setCustomEnv({ window, document });
 
-  const { node } = componentBuilder(props, window, document);
+  const node = componentBuilder({ window, document });
 
   window.addEventListener("load", () => {
     forgo.mount(node, document.getElementById("root"));

--- a/src/test/rerender.tsx
+++ b/src/test/rerender.tsx
@@ -2,102 +2,112 @@ import should from "should";
 
 import * as forgo from "../index.js";
 import { run } from "./componentRunner.js";
-
-import type { ForgoRenderArgs } from "../index.js";
+import type { ForgoRef, ForgoRenderArgs } from "../index.js";
 import { DOMWindow } from "jsdom";
 
 const unmanagedNodeTagName = "article";
 
-let buttonElement: forgo.ForgoRef<HTMLButtonElement> = {};
-let rootElement: forgo.ForgoRef<HTMLDivElement> = {};
-let subrootElement: forgo.ForgoRef<HTMLDivElement> = {};
-let pElement: forgo.ForgoRef<HTMLParagraphElement> = {};
-let remove: () => void;
-
-/* To be called in beforeEach() */
-function clear() {
-  buttonElement = {};
-  rootElement = {};
-  subrootElement = {};
-  pElement = {};
-  remove = () => {};
-}
-
-function Component(props: {
-  insertionPosition?: "first" | "last" | number;
-  window: DOMWindow;
-  document: Document;
-}) {
-  let counter = 0;
-  let insertAfterRender = true;
-  const { insertionPosition, window, document } = props;
-
-  const addChild = (el: HTMLElement, tag: string) => {
-    if (!insertionPosition) return;
-
-    // We create an <article> so that it's very obvious if a bug causes forgo to
-    // treat the node as a managed dom node and transform its props/children
-    const newElement = document.createElement(unmanagedNodeTagName);
-    newElement.setAttribute("data-forgo", tag);
-    switch (insertionPosition) {
-      case "first":
-        el.prepend(newElement);
-        break;
-      case "last":
-        el.append(newElement);
-        break;
-      default:
-        el.insertBefore(
-          newElement,
-          Array.from(el.childNodes)[insertionPosition]
-        );
-    }
+function componentFactory() {
+  const state: {
+    buttonElement: ForgoRef<HTMLButtonElement>;
+    rootElement: ForgoRef<HTMLDivElement>;
+    subrootElement: ForgoRef<HTMLDivElement>;
+    pElement: ForgoRef<HTMLParagraphElement>;
+    remove: () => void;
+  } = {
+    buttonElement: {},
+    rootElement: {},
+    subrootElement: {},
+    pElement: {},
+    remove: () => {},
   };
 
-  return {
-    afterRender() {
-      if (!insertAfterRender) return;
-      addChild(rootElement.value!, "child-of-root");
-      if (insertionPosition === "first") {
-        addChild(subrootElement.value!, "child-of-subroot");
-      }
-    },
-    render(_props: any, { update }: ForgoRenderArgs) {
-      function updateCounter() {
-        counter++;
-        update();
-      }
-      remove = () => {
-        rootElement
-          .value!.querySelectorAll("[data-forgo]")
-          .forEach((el) => el.remove());
-        // The test that uses this asserts that all these nodes are gone, so
-        // don't add one after we call update(). We have to call update() to
-        // know that Forgo doesn't misbehave when nodes it saw before disappear.
-        insertAfterRender = false;
-        update();
-      };
+  function Component(props: {
+    insertionPosition?: "first" | "last" | number;
+    window: DOMWindow;
+    document: Document;
+  }) {
+    let counter = 0;
+    let insertAfterRender = true;
+    const { insertionPosition, document } = props;
 
-      return (
-        <div ref={rootElement} id="root">
-          <button onclick={updateCounter} ref={buttonElement} id="button">
-            Click me!
-          </button>
-          <p id="p" ref={pElement}>
-            Clicked {counter} times
-          </p>
-          <div ref={subrootElement} id="subRoot"></div>
-        </div>
-      );
-    },
+    const addChild = (el: HTMLElement, tag: string) => {
+      if (!insertionPosition) return;
+
+      // We create an <article> so that it's very obvious if a bug causes forgo to
+      // treat the node as a managed dom node and transform its props/children
+      const newElement = document.createElement(unmanagedNodeTagName);
+      newElement.setAttribute("data-forgo", tag);
+      switch (insertionPosition) {
+        case "first":
+          el.prepend(newElement);
+          break;
+        case "last":
+          el.append(newElement);
+          break;
+        default:
+          el.insertBefore(
+            newElement,
+            Array.from(el.childNodes)[insertionPosition]
+          );
+      }
+    };
+
+    return {
+      afterRender() {
+        if (!insertAfterRender) return;
+        addChild(state.rootElement.value!, "child-of-root");
+        if (insertionPosition === "first") {
+          addChild(state.subrootElement.value!, "child-of-subroot");
+        }
+      },
+      render(_props: any, { update }: ForgoRenderArgs) {
+        function updateCounter() {
+          counter++;
+          update();
+        }
+        state.remove = () => {
+          state.rootElement
+            .value!.querySelectorAll("[data-forgo]")
+            .forEach((el) => el.remove());
+          // The test that uses this asserts that all these nodes are gone, so
+          // don't add one after we call update(). We have to call update() to
+          // know that Forgo doesn't misbehave when nodes it saw before disappear.
+          insertAfterRender = false;
+          update();
+        };
+
+        return (
+          <div ref={state.rootElement} id="root">
+            <button
+              onclick={updateCounter}
+              ref={state.buttonElement}
+              id="button"
+            >
+              Click me!
+            </button>
+            <p id="p" ref={state.pElement}>
+              Clicked {counter} times
+            </p>
+            <div ref={state.subrootElement} id="subRoot"></div>
+          </div>
+        );
+      },
+    };
+  }
+  return {
+    Component,
+    state,
   };
 }
 
 export default function () {
   describe("rerendering", () => {
-    beforeEach(clear);
-
     it("rerenders", async () => {
+      const {
+        Component,
+        state: { buttonElement },
+      } = componentFactory();
       const { window } = await run((env) => <Component {...env} />);
 
       buttonElement.value!.click();
@@ -113,45 +123,51 @@ export default function () {
      * not specified as part of the JSX.
      */
     it("preserves children inserted with DOM APIs that are prepended to the front of the children list", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => (
         <Component insertionPosition={"first" as const} {...env} />
       ));
 
-      should.equal(subrootElement.value!.children.length, 1);
+      should.equal(state.subrootElement.value!.children.length, 1);
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
-          .length,
+        state.rootElement.value!.querySelectorAll(
+          '[data-forgo="child-of-root"]'
+        ).length,
         1,
         "Root element should have the appended element"
       );
 
-      buttonElement.value!.click();
+      state.buttonElement.value!.click();
 
-      should.equal(subrootElement.value!.children.length, 2);
+      should.equal(state.subrootElement.value!.children.length, 2);
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
-          .length,
+        state.rootElement.value!.querySelectorAll(
+          '[data-forgo="child-of-root"]'
+        ).length,
         2,
         "Root element should have both appended elements"
       );
     });
 
     it("preserves children inserted with DOM APIs that are appended after of managed children", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => (
         <Component insertionPosition={"last" as const} {...env} />
       ));
 
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
+        state.rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
           .length,
         1,
         "Root element should have the appended element"
       );
 
-      buttonElement.value!.click();
+      state.buttonElement.value!.click();
 
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
+        state.rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
           .length,
         2,
         "Root element should have both appended elements"
@@ -159,19 +175,21 @@ export default function () {
     });
 
     it("preserves children inserted with DOM APIs that inserted in the middle of managed children", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => <Component insertionPosition={2} {...env} />);
 
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
+        state.rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
           .length,
         1,
         "Root element should have the appended element"
       );
 
-      buttonElement.value!.click();
+      state.buttonElement.value!.click();
 
       should.equal(
-        rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
+        state.rootElement.value!.querySelectorAll('[data-forgo="child-of-root"]')
           .length,
         2,
         "Root element should have both appended elements"
@@ -179,15 +197,17 @@ export default function () {
     });
 
     it("doesn't add attributes to unmanaged elements", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => <Component insertionPosition={2} {...env} />);
 
-      const el = rootElement.value!.querySelector(
+      const el = state.rootElement.value!.querySelector(
         '[data-forgo="child-of-root"]'
       )!;
 
       // Mutate the component to force it to interact with the unmanaged element
       // we added after the first render
-      buttonElement.value!.click();
+      state.buttonElement.value!.click();
 
       should.equal(Array.from(el.attributes).length, 1);
       const [{ name: attrName, value: attrValue }] = Array.from(el.attributes);
@@ -204,13 +224,15 @@ export default function () {
      * managed nodes.
      */
     it("doesn't convert an unmanaged element into a managed element", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => <Component insertionPosition={2} {...env} />);
 
       // Mutate the component to force it to interact with the unmanaged element
       // we added after the first render
-      buttonElement.value!.click();
+      state.buttonElement.value!.click();
 
-      [buttonElement, pElement, subrootElement].forEach((el) =>
+      [state.buttonElement, state.pElement, state.subrootElement].forEach((el) =>
         should.notEqual(el.value!.tagName, unmanagedNodeTagName)
       );
 
@@ -218,9 +240,9 @@ export default function () {
       // covers if there's any case where Forgo mis-transforms the elements
       // without updating the ref.
       [
-        rootElement.value!.querySelector("#button"),
-        rootElement.value!.querySelector("#p"),
-        rootElement.value!.querySelector("#subRoot"),
+        state.rootElement.value!.querySelector("#button"),
+        state.rootElement.value!.querySelector("#p"),
+        state.rootElement.value!.querySelector("#subRoot"),
       ].forEach((el) => {
         should.exist(el);
         should.notEqual(el!.tagName, unmanagedNodeTagName);
@@ -228,30 +250,32 @@ export default function () {
     });
 
     it("leaves managed nodes alone when an unmanaged node is removed from the DOM", async () => {
+      const { Component, state } = componentFactory();
+
       await run((env) => <Component insertionPosition={2} {...env} />);
 
       // Sanity check that our tests are correctly identifying unmanaged nodes
       // before testing their removal
       should.notEqual(
-        rootElement.value!.querySelectorAll("[data-forgo]").length,
+        state.rootElement.value!.querySelectorAll("[data-forgo]").length,
         0
       );
       // Mutate the component to force it to interact with the unmanaged element
       // we added after the first render
-      buttonElement.value!.click();
-      remove();
+      state.buttonElement.value!.click();
+      state.remove();
 
       // All unmanaged nodes are gone
       should.equal(
-        rootElement.value!.querySelectorAll("[data-forgo]").length,
+        state.rootElement.value!.querySelectorAll("[data-forgo]").length,
         0
       );
 
       // All managed nodes still exist
       [
-        rootElement.value!.querySelector("#button"),
-        rootElement.value!.querySelector("#p"),
-        rootElement.value!.querySelector("#subRoot"),
+        state.rootElement.value!.querySelector("#button"),
+        state.rootElement.value!.querySelector("#p"),
+        state.rootElement.value!.querySelector("#subRoot"),
       ].forEach((el) => {
         should.exist(el);
         should.notEqual(el!.tagName, unmanagedNodeTagName);

--- a/src/test/rootElementChangeDoesNotUnmount.tsx
+++ b/src/test/rootElementChangeDoesNotUnmount.tsx
@@ -1,42 +1,32 @@
 import should from "should";
 import * as forgo from "../index.js";
-import { ComponentEnvironment, run } from "./componentRunner.js";
-import type {
-  ForgoComponentCtor,
-  ForgoComponentProps,
-  ForgoRenderArgs,
-} from "../index.js";
+import { run } from "./componentRunner.js";
+import type { ForgoRenderArgs } from "../index.js";
 
-const Component: ForgoComponentCtor<
-  ForgoComponentProps &
-    ComponentEnvironment<{
-      renderArgs: ForgoRenderArgs;
-      renderCount: number;
-      unmountCount: number;
-    }> & {}
-> = ({ exports }) => {
-  exports.unmountCount = 0;
-  exports.renderCount = 0;
+export let unmountCount = 0;
+export let renderCount = 0;
+export let renderArgs: ForgoRenderArgs;
 
+function Component() {
   function Child() {
     return {
       render(props: any, args: ForgoRenderArgs) {
-        exports.renderCount++;
-        if (exports.renderCount % 2 === 0) {
+        renderCount++;
+        if (renderCount % 2 === 0) {
           return <div>This is a div</div>;
         } else {
           return <p>But this is a paragraph</p>;
         }
       },
       unmount() {
-        exports.unmountCount++;
+        unmountCount++;
       },
     };
   }
 
   return {
     render(props: any, args: ForgoRenderArgs) {
-      exports.renderArgs = args;
+      renderArgs = args;
       return (
         <section>
           <Child />
@@ -44,21 +34,21 @@ const Component: ForgoComponentCtor<
       );
     },
   };
-};
+}
 
 export default function () {
   describe("root element changes", () => {
     it("does not unmount", async () => {
-      const { window, exports } = await run(Component, {});
+      await run(<Component />, {});
 
-      exports.renderArgs.update();
-      exports.renderArgs.update();
-      exports.renderArgs.update();
-      exports.renderArgs.update();
-      exports.renderArgs.update();
+      renderArgs.update();
+      renderArgs.update();
+      renderArgs.update();
+      renderArgs.update();
+      renderArgs.update();
 
-      exports.renderCount.should.equal(6);
-      exports.unmountCount.should.equal(0);
+      renderCount.should.equal(6);
+      unmountCount.should.equal(0);
     });
   });
 }

--- a/src/test/rootElementChangeDoesNotUnmount.tsx
+++ b/src/test/rootElementChangeDoesNotUnmount.tsx
@@ -3,52 +3,62 @@ import * as forgo from "../index.js";
 import { run } from "./componentRunner.js";
 import type { ForgoRenderArgs } from "../index.js";
 
-let unmountCount = 0;
-let renderCount = 0;
-let renderArgs: ForgoRenderArgs;
+function componentFactory() {
+  const state = {
+    unmountCount: 0,
+    renderCount: 0,
+    renderArgs: undefined as ForgoRenderArgs | undefined,
+  };
 
-function Component() {
-  function Child() {
+  function Component() {
+    function Child() {
+      return {
+        render(props: any, args: ForgoRenderArgs) {
+          state.renderCount++;
+          if (state.renderCount % 2 === 0) {
+            return <div>This is a div</div>;
+          } else {
+            return <p>But this is a paragraph</p>;
+          }
+        },
+        unmount() {
+          state.unmountCount++;
+        },
+      };
+    }
+
     return {
       render(props: any, args: ForgoRenderArgs) {
-        renderCount++;
-        if (renderCount % 2 === 0) {
-          return <div>This is a div</div>;
-        } else {
-          return <p>But this is a paragraph</p>;
-        }
-      },
-      unmount() {
-        unmountCount++;
+        state.renderArgs = args;
+        return (
+          <section>
+            <Child />
+          </section>
+        );
       },
     };
   }
 
   return {
-    render(props: any, args: ForgoRenderArgs) {
-      renderArgs = args;
-      return (
-        <section>
-          <Child />
-        </section>
-      );
-    },
+    Component,
+    state,
   };
 }
 
 export default function () {
   describe("root element changes", () => {
     it("does not unmount", async () => {
+      const { Component, state } = componentFactory();
       await run(() => <Component />);
 
-      renderArgs.update();
-      renderArgs.update();
-      renderArgs.update();
-      renderArgs.update();
-      renderArgs.update();
+      state.renderArgs!.update();
+      state.renderArgs!.update();
+      state.renderArgs!.update();
+      state.renderArgs!.update();
+      state.renderArgs!.update();
 
-      renderCount.should.equal(6);
-      unmountCount.should.equal(0);
+      state.renderCount.should.equal(6);
+      state.unmountCount.should.equal(0);
     });
   });
 }

--- a/src/test/rootElementChangeDoesNotUnmount.tsx
+++ b/src/test/rootElementChangeDoesNotUnmount.tsx
@@ -3,9 +3,9 @@ import * as forgo from "../index.js";
 import { run } from "./componentRunner.js";
 import type { ForgoRenderArgs } from "../index.js";
 
-export let unmountCount = 0;
-export let renderCount = 0;
-export let renderArgs: ForgoRenderArgs;
+let unmountCount = 0;
+let renderCount = 0;
+let renderArgs: ForgoRenderArgs;
 
 function Component() {
   function Child() {
@@ -39,7 +39,7 @@ function Component() {
 export default function () {
   describe("root element changes", () => {
     it("does not unmount", async () => {
-      await run(<Component />, {});
+      await run(() => <Component />);
 
       renderArgs.update();
       renderArgs.update();


### PR DESCRIPTION
This PR attempts to simplify the usage of componentRunner().

Benefits:
- removes the need to specify types for exports 
- the name exports can be confusing w.r.t. Node's exports
- Less code

The following code is now simpler:

```tsx
const Component: ForgoComponentCtor<
  ForgoComponentProps &
    ComponentEnvironment<{
      buttonElement: forgo.ForgoRef<HTMLButtonElement>;
      rootElement: forgo.ForgoRef<HTMLDivElement>;
      subrootElement: forgo.ForgoRef<HTMLDivElement>;
      pElement: forgo.ForgoRef<HTMLParagraphElement>;
      remove: () => void;
    }> & { insertionPosition?: "first" | "last" | number }
> = ({ document, exports, insertionPosition }) => {
  // ......
}
```